### PR TITLE
Adding CI/CD

### DIFF
--- a/Jenkinsfile_PR
+++ b/Jenkinsfile_PR
@@ -1,0 +1,23 @@
+pipeline {
+  agent any
+  stages {
+    stage('Integration') {
+      agent any
+      steps {
+        sh 'docker network create --attachable network-integration_tests-$BUILD_ID'
+        sh 'docker build . -t integration-tests_build-$BUILD_ID'
+        sh 'docker run -t -d --privileged --network=network-integration_tests-$BUILD_ID -v /.kube:/.kube/ --name docker-integration_tests-$BUILD_ID asperathos-docker'
+        sh 'docker run -i --network=network-integration_tests-$BUILD_ID --name integration-tests-integration_tests-$BUILD_ID -e DOCKER_HOST=tcp://$(docker ps -aqf "name=docker-integration_tests-$BUILD_ID"):2375 -e DOCKER_HOST_URL=$(docker ps -aqf "name=docker-integration_tests-$BUILD_ID") integration-tests_build-$BUILD_ID'
+      }
+    }
+  }
+  post {
+    cleanup {
+      sh 'docker stop docker-integration_tests-$BUILD_ID'
+      sh 'docker rm -v docker-integration_tests-$BUILD_ID'
+      sh 'docker rm -v integration-tests-integration_tests-$BUILD_ID'
+      sh 'docker network rm network-integration_tests-$BUILD_ID'
+      sh 'docker image rm integration-tests_build-$BUILD_ID'
+    }
+  }
+}

--- a/Jenkinsfile_commit
+++ b/Jenkinsfile_commit
@@ -1,0 +1,29 @@
+pipeline {
+  agent any
+  stages {
+    stage('Integration') {
+      agent any
+      steps {
+        sh 'docker network create --attachable network-integration_tests-$BUILD_ID'
+        sh 'docker build . -t integration-tests_build-$BUILD_ID'
+        sh 'docker run -t -d --privileged --network=network-integration_tests-$BUILD_ID -v /.kube:/.kube/ --name docker-integration_tests-$BUILD_ID asperathos-docker'
+        sh 'docker run -i --network=network-integration_tests-$BUILD_ID --name integration-tests-integration_tests-$BUILD_ID -e DOCKER_HOST=tcp://$(docker ps -aqf "name=docker-integration_tests-$BUILD_ID"):2375 -e DOCKER_HOST_URL=$(docker ps -aqf "name=docker-integration_tests-$BUILD_ID") integration-tests_build-$BUILD_ID'
+      }
+    }
+  }
+  post {
+    cleanup {
+      sh 'docker stop docker-integration_tests-$BUILD_ID'
+      sh 'docker rm -v docker-integration_tests-$BUILD_ID'
+      sh 'docker rm -v integration-tests-integration_tests-$BUILD_ID'
+      sh 'docker network rm network-integration_tests-$BUILD_ID'
+    }
+    success {
+        sh 'docker image tag integration-tests_build-$BUILD_ID integration-tests:latest'
+        sh 'docker image rm integration-tests_build-$BUILD_ID'
+    }
+    failure {
+        sh 'docker image rm integration-tests_build-$BUILD_ID'
+    }
+  }
+}


### PR DESCRIPTION
This PR is able to add CI/CD to integration tests repositories.
The reason why there's 2 Jenkinsfiles is to only allow CD, i.e., override old image with new one, only to commits to master.