### PR TITLE
Add demos to integration tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM python:2.7
-RUN curl -fsSL https://get.docker.com | bash
+FROM integration_tests_base
 RUN apt install docker-compose -y
-COPY . ./integration-tests/
+COPY . /integration-tests/
 WORKDIR /integration-tests/
 RUN pip install -r requirements.txt
 ENTRYPOINT cd test_env && ./build.sh && docker-compose up -d && sleep 2m && cd .. && tox

--- a/Jenkinsfile_PR
+++ b/Jenkinsfile_PR
@@ -4,20 +4,29 @@ pipeline {
     stage('Integration') {
       agent any
       steps {
-        sh 'docker network create --attachable network-integration_tests-$BUILD_ID'
-        sh 'docker build . -t integration-tests_build-$BUILD_ID'
-        sh 'docker run -t -d --privileged --network=network-integration_tests-$BUILD_ID -v /.kube:/.kube/ --name docker-integration_tests-$BUILD_ID asperathos-docker'
-        sh 'docker run -i --network=network-integration_tests-$BUILD_ID --name integration-tests-integration_tests-$BUILD_ID -e DOCKER_HOST=tcp://$(docker ps -aqf "name=docker-integration_tests-$BUILD_ID"):2375 -e DOCKER_HOST_URL=$(docker ps -aqf "name=docker-integration_tests-$BUILD_ID") integration-tests_build-$BUILD_ID'
+        labelledShell script: 'docker network create --attachable network-integration_tests-$BUILD_ID', label: "Create test network"
+        labelledShell script: 'docker build . -t integration-tests_build-$BUILD_ID', label: "Build image"
+        labelledShell script: 'docker volume create d54-data-$BUILD_ID', label: "Create volume for D5.4 demo"
+        labelledShell script: 'docker volume create organon-data-$BUILD_ID', label: "Create volume for Organon demo"
+        labelledShell script: 'docker run -t -d --privileged --network=network-integration_tests-$BUILD_ID -v /.kube:/.kube/ -v d54-data-$BUILD_ID:/demo-tests/d54 -v organon-data-$BUILD_ID:/demo-tests/organon --name docker-integration_tests-$BUILD_ID asperathos-docker', label: "Run Docker container"
+        labelledShell script: """docker run -i --network=network-integration_tests-$BUILD_ID -v d54-data-$BUILD_ID:/demo-tests/d54 \
+        -v organon-data-$BUILD_ID:/demo-tests/organon --name integration-tests-integration_tests-$BUILD_ID \
+        -e DOCKER_HOST=tcp://docker-integration_tests-$BUILD_ID:2375 \
+        -e DOCKER_HOST_URL=docker-integration_tests-$BUILD_ID \
+        -e ASPERATHOS_URL=docker-integration_tests-$BUILD_ID:1500/submissions \
+        -e VISUALIZER_URL=docker-integration_tests-$BUILD_ID:5002/visualizing  integration-tests_build-$BUILD_ID""" , label: "Run integration tests"
       }
     }
   }
   post {
     cleanup {
-      sh 'docker stop docker-integration_tests-$BUILD_ID'
-      sh 'docker rm -v docker-integration_tests-$BUILD_ID'
-      sh 'docker rm -v integration-tests-integration_tests-$BUILD_ID'
-      sh 'docker network rm network-integration_tests-$BUILD_ID'
-      sh 'docker image rm integration-tests_build-$BUILD_ID'
+      labelledShell script: 'docker stop docker-integration_tests-$BUILD_ID', label: "Stop Docker container"
+      labelledShell script: 'docker rm -v docker-integration_tests-$BUILD_ID', label: "Remove Docker container"
+      labelledShell script: 'docker rm -v integration-tests-integration_tests-$BUILD_ID', label: "Remove integration tests container"
+      labelledShell script: 'docker network rm network-integration_tests-$BUILD_ID', label: "Remove test network"
+      labelledShell script: 'docker volume rm d54-data-$BUILD_ID', label: "Remove D5.4 volume"
+      labelledShell script: 'docker volume rm organon-data-$BUILD_ID', label: "Remove Organon volume"
+      labelledShell script: 'docker image rm integration-tests_build-$BUILD_ID', label: "Remove build image"
     }
   }
 }

--- a/Jenkinsfile_commit
+++ b/Jenkinsfile_commit
@@ -4,26 +4,35 @@ pipeline {
     stage('Integration') {
       agent any
       steps {
-        sh 'docker network create --attachable network-integration_tests-$BUILD_ID'
-        sh 'docker build . -t integration-tests_build-$BUILD_ID'
-        sh 'docker run -t -d --privileged --network=network-integration_tests-$BUILD_ID -v /.kube:/.kube/ --name docker-integration_tests-$BUILD_ID asperathos-docker'
-        sh 'docker run -i --network=network-integration_tests-$BUILD_ID --name integration-tests-integration_tests-$BUILD_ID -e DOCKER_HOST=tcp://$(docker ps -aqf "name=docker-integration_tests-$BUILD_ID"):2375 -e DOCKER_HOST_URL=$(docker ps -aqf "name=docker-integration_tests-$BUILD_ID") integration-tests_build-$BUILD_ID'
+        labelledShell script: 'docker network create --attachable network-integration_tests-$BUILD_ID', label: "Create test network"
+        labelledShell script: 'docker build . -t integration-tests_build-$BUILD_ID', label: "Build image"
+        labelledShell script: 'docker volume create d54-data-$BUILD_ID', label: "Create volume for D5.4 demo"
+        labelledShell script: 'docker volume create organon-data-$BUILD_ID', label: "Create volume for Organon demo"
+        labelledShell script: 'docker run -t -d --privileged --network=network-integration_tests-$BUILD_ID -v /.kube:/.kube/ -v d54-data-$BUILD_ID:/demo-tests/d54 -v organon-data-$BUILD_ID:/demo-tests/organon --name docker-integration_tests-$BUILD_ID asperathos-docker', label: "Run Docker container"
+        labelledShell script: """docker run -i --network=network-integration_tests-$BUILD_ID -v d54-data-$BUILD_ID:/demo-tests/d54 \
+        -v organon-data-$BUILD_ID:/demo-tests/organon --name integration-tests-integration_tests-$BUILD_ID \
+        -e DOCKER_HOST=tcp://docker-integration_tests-$BUILD_ID:2375 \
+        -e DOCKER_HOST_URL=docker-integration_tests-$BUILD_ID \
+        -e ASPERATHOS_URL=docker-integration_tests-$BUILD_ID:1500/submissions \
+        -e VISUALIZER_URL=docker-integration_tests-$BUILD_ID:5002/visualizing  integration-tests_build-$BUILD_ID""" , label: "Run integration tests"
       }
     }
   }
   post {
-    cleanup {
-      sh 'docker stop docker-integration_tests-$BUILD_ID'
-      sh 'docker rm -v docker-integration_tests-$BUILD_ID'
-      sh 'docker rm -v integration-tests-integration_tests-$BUILD_ID'
-      sh 'docker network rm network-integration_tests-$BUILD_ID'
+    always {
+      labelledShell script: 'docker stop docker-integration_tests-$BUILD_ID', label: "Stop Docker container"
+      labelledShell script: 'docker rm -v docker-integration_tests-$BUILD_ID', label: "Remove Docker container"
+      labelledShell script: 'docker rm -v integration-tests-integration_tests-$BUILD_ID', label: "Remove integration tests container"
+      labelledShell script: 'docker network rm network-integration_tests-$BUILD_ID', label: "Remove test network"
+      labelledShell script: 'docker volume rm d54-data-$BUILD_ID', label: "Remove D5.4 volume"
+      labelledShell script: 'docker volume rm organon-data-$BUILD_ID', label: "Remove Organon volume"
     }
     success {
-        sh 'docker image tag integration-tests_build-$BUILD_ID integration-tests:latest'
-        sh 'docker image rm integration-tests_build-$BUILD_ID'
+        labelledShell script: 'docker image tag integration-tests_build-$BUILD_ID integration-tests:latest', label: "Tag image"
+        labelledShell script: 'docker image rm integration-tests_build-$BUILD_ID', label: "Remove build image"
     }
     failure {
-        sh 'docker image rm integration-tests_build-$BUILD_ID'
+        labelledShell script: 'docker image rm integration-tests_build-$BUILD_ID', label: "Remove build image"
     }
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,13 +5,34 @@ services:
         privileged: true
         restart: always
         volumes:
-            - ${KUBECONFIG}/..:/.kube/
+            - /.kube/:/.kube/
+            - d54-data:/demo-tests/d54
+            - organon-data:/demo-tests/organon
     tests:
         build: .
         environment:
             DOCKER_HOST: tcp://docker:2375
             DOCKER_HOST_URL: docker
+            ASPERATHOS_URL: docker:1500/submissions
+            VISUALIZER_URL: docker:5002/visualizing
+            WRAPPER_IMAGE: 10.11.5.6:5000/secure-demo/wrapper:worker-fortran
+            OS_PROJECT_DOMAIN_NAME: LSD
+            OS_USER_DOMAIN_NAME: LSD
+            OS_PROJECT_NAME: asperathos
+            OS_USERNAME: asperathos
+            OS_PASSWORD: 4sp3r4th0s-us3r
+            OS_PROJECT_ID: 03fff10deb3d4c4db5317acae3055e0f
+            OS_AUTH_URL: https://secure-cloud.lsd.ufcg.edu.br:5000/v3
+
         volumes:
             - .:/integration-tests/.
+            - d54-data:/demo-tests/d54
+            - organon-data:/demo-tests/organon
         depends_on:
             - docker
+
+volumes:
+    d54-data:
+        external: true
+    organon-data:
+        external: true

--- a/test_env/monitor/Dockerfile
+++ b/test_env/monitor/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:2.7
 COPY ./asperathos-monitor /asperathos-monitor
 WORKDIR /asperathos-monitor
+COPY ./monitor.cfg ./monitor.cfg
 RUN pip install setuptools tox flake8
 ENTRYPOINT ./run.sh

--- a/test_env/monitor/monitor.cfg
+++ b/test_env/monitor/monitor.cfg
@@ -1,0 +1,24 @@
+[general]
+host = 0.0.0.0
+port = 5001
+plugins = openstack_generic,external_api
+debug = True
+retries = 5
+
+[openstack_generic]
+key_pair = /home/asperathos/.ssh/asperathos_key
+retries = 30
+
+[monasca]
+monasca_endpoint = https://url.com
+username = user
+password = password
+project_name = projname
+auth_url = https://auth-url.com
+api_version = 2_0
+
+[external_api]
+metric_source = cpu
+get_metric_endpoint = cpu-quota
+threshold = 0.5
+k8s_manifest = /.kube/config

--- a/tests/demos/test_d54_organon.py
+++ b/tests/demos/test_d54_organon.py
@@ -1,0 +1,36 @@
+import subprocess
+import os
+import math
+
+def test_d54():
+    ls_command = 'ls -p /demo-tests/d54'
+    test_command = 'cd /demo-tests/d54 && bash import-dataset.sh ${PWD}/dataset ${PWD}/worker ${PWD}/invmat.yml'
+    output_path = '/demo-tests/d54/{}commfile1.txt/OUTPUTS/output.out'
+    folders_before = subprocess.check_output(ls_command, shell=True).split()
+    subprocess.run([test_command], shell=True)
+    folders_after = subprocess.check_output(ls_command, shell=True).split()
+    new_job = list(set(folders_after).difference(set(folders_before)))[0]
+    new_job = new_job.decode()
+
+    with open(output_path.format(new_job)) as f:
+        value1, value2 = [float(l.strip()) for l in f.readlines()]
+        expected_result_1 = 1.583333333
+        expected_result_2 = -0.83333333
+        assert math.isclose(value1, expected_result_1, abs_tol=0.001)
+        assert math.isclose(value2, expected_result_2, abs_tol=0.001)
+
+
+def test_organon():
+    ls_command = 'ls -p /demo-tests/organon'
+    ctg_number = '1' #Paramater for the organon script
+    output_path = '/demo-tests/organon/{}9bus-00.ntw-ctg1/OUTPUTS/STATIC.csv' #Output address without the job formatting
+    expected_output_path = '/demo-tests/organon/expected_results.csv'
+    test_command = 'cd /demo-tests/organon && bash import-dataset.sh ${PWD}/dataset ${PWD}/worker ${PWD}/organon.yml ' + ctg_number
+    folders_before = subprocess.check_output(ls_command, shell=True).split()
+    subprocess.run([test_command], shell=True)
+    folders_after = subprocess.check_output(ls_command, shell=True).split()
+    new_job = list(set(folders_after).difference(set(folders_before)))[0]
+    new_job = new_job.decode()
+    new_output = open(output_path.format(new_job)).read()
+    expected_output = open(expected_output_path).read()
+    assert new_output == expected_output

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,10 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27
+envlist = py35
 
 [testenv]
-passenv = DOCKER_HOST_URL
+passenv = DOCKER_HOST DOCKER_HOST_URL ASPERATHOS_URL VISUALIZER_URL WRAPPER_IMAGE OS_PROJECT_DOMAIN_NAME OS_USER_DOMAIN_NAME OS_PROJECT_NAME OS_USERNAME OS_PASSWORD OS_PROJECT_ID OS_AUTH_URL
 commands = pytest --ignore=test_env
 deps =
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
This PR is able to add D5.4 and Organon demos to the integration tests.
Changes are:
- Now we use a base image to build the integration tests' one. This base image includes D5.4 and Organon demo files as well as env vars used in these tests. Source code can be found here: https://git.lsd.ufcg.edu.br/matheusmelo/asperathos-integration_tests_base
- Add monitor.cfg file in order to Monitor work properly
- Also adds cute messages in every Jenkins build step

Jenkins Build: http://150.165.15.68/blue/organizations/jenkins/asperathos-integration-tests/detail/PR-9/1/pipeline